### PR TITLE
Fix TestRunStepGit

### DIFF
--- a/tests/connector_test.go
+++ b/tests/connector_test.go
@@ -27,7 +27,7 @@ var inOutConfigGitPullIfNotPresent = `
 `
 
 func TestRunStepGit(t *testing.T) {
-	moduleName := "arcaflow-plugin-template-python@git+https://github.com/arcalot/arcaflow-plugin-template-python.git@6145c2cd0760495ea6dc5b7399b6d7692e81d368"
+	moduleName := "arcaflow-plugin-template-python@git+https://github.com/arcalot/arcaflow-plugin-template-python.git"
 	connector, _ := getConnector(t, inOutConfigGitPullAlways, nil)
 	outputID, outputData, err := RunStep(t, connector, moduleName)
 	assert.Equals(t, *outputID, "success")


### PR DESCRIPTION
The test was pointing to a git SHA that no longer exists, now points to the main branch