### PR TITLE
Fix Panic Error pythonPath

### DIFF
--- a/factory.go
+++ b/factory.go
@@ -1,11 +1,16 @@
 package pythondeployer
 
 import (
-	"go.flow.arcalot.io/pythondeployer/internal/cliwrapper"
-	"go.flow.arcalot.io/pythondeployer/internal/config"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
 	"go.arcalot.io/log/v2"
 	"go.flow.arcalot.io/deployer"
 	"go.flow.arcalot.io/pluginsdk/schema"
+	"go.flow.arcalot.io/pythondeployer/internal/cliwrapper"
+	"go.flow.arcalot.io/pythondeployer/internal/config"
 )
 
 // NewFactory creates a new factory for the Docker deployer.
@@ -25,10 +30,33 @@ func (f factory) ConfigurationSchema() *schema.TypedScopeSchema[*config.Config] 
 }
 
 func (f factory) Create(config *config.Config, logger log.Logger) (deployer.Connector, error) {
-	python := cliwrapper.NewCliWrapper(config.PythonPath, config.WorkDir, logger)
+	pythonPath, err := binaryCheck(config.PythonPath)
+	if err != nil {
+		return &Connector{}, fmt.Errorf("python binary check failed with error: %w", err)
+	}
+	python := cliwrapper.NewCliWrapper(pythonPath, config.WorkDir, logger)
 	return &Connector{
 		config:           config,
 		logger:           logger,
 		pythonCliWrapper: python,
 	}, nil
+}
+
+// binaryCheck validates there is a python binary in a valid absolute path
+func binaryCheck(pythonPath string) (string, error) {
+	if pythonPath == "" {
+		pythonPath = "python"
+	}
+	if !filepath.IsAbs(pythonPath) {
+		pythonPathAbs, err := exec.LookPath(pythonPath)
+		if err != nil {
+			return "", fmt.Errorf("pythonPath executable not found in a valid path with error: %w", err)
+
+		}
+		pythonPath = pythonPathAbs
+	}
+	if _, err := os.Stat(pythonPath); err != nil {
+		return "", fmt.Errorf("pythons binary not found with error: %w", err)
+	}
+	return pythonPath, nil
 }

--- a/schema.go
+++ b/schema.go
@@ -1,20 +1,12 @@
 package pythondeployer
 
 import (
+	"regexp"
+
+	"go.flow.arcalot.io/pluginsdk/schema"
 	"go.flow.arcalot.io/pythondeployer/internal/config"
 	"go.flow.arcalot.io/pythondeployer/internal/util"
-	"go.flow.arcalot.io/pluginsdk/schema"
-	"os/exec"
-	"regexp"
 )
-
-func pythonGetDefaultPath() string {
-	path, err := exec.LookPath("python")
-	if err != nil {
-		panic("python binary not found in $PATH, please provide it in configuration")
-	}
-	return path
-}
 
 // Schema describes the deployment options of the Docker deployment mechanism.
 var Schema = schema.NewTypedScopeSchema[*config.Config](
@@ -29,7 +21,7 @@ var Schema = schema.NewTypedScopeSchema[*config.Config](
 				nil,
 				nil,
 				nil,
-				schema.PointerTo(util.JSONEncode(pythonGetDefaultPath())),
+				nil,
 				nil,
 			),
 			"workdir": schema.NewPropertySchema(

--- a/schema.go
+++ b/schema.go
@@ -21,7 +21,7 @@ var Schema = schema.NewTypedScopeSchema[*config.Config](
 				nil,
 				nil,
 				nil,
-				nil,
+				schema.PointerTo(util.JSONEncode("python")),
 				nil,
 			),
 			"workdir": schema.NewPropertySchema(


### PR DESCRIPTION
## Changes introduced with this PR

I am removing the panic from the python path not being found. This way it should only error the python deployer is being used and fails.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).