### PR TITLE
switch from wait plugin to utilities plugin for wait step

### DIFF
--- a/internal/cliwrapper/cliwrapper_test.go
+++ b/internal/cliwrapper/cliwrapper_test.go
@@ -3,13 +3,14 @@ package cliwrapper_test
 import (
 	"errors"
 	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
 	"go.arcalot.io/assert"
 	"go.arcalot.io/exex"
 	"go.arcalot.io/log/v2"
 	"go.flow.arcalot.io/pythondeployer/internal/cliwrapper"
-	"os"
-	"os/exec"
-	"testing"
 )
 
 type TestModule struct {
@@ -64,7 +65,7 @@ func Test_PullModule_NonexistentGitLocation(t *testing.T) {
 // when the location provided included a typo.
 func Test_PullModule_ErrorModuleNameFmt(t *testing.T) {
 	testModule := TestModule{
-		Location: "git+https://github.com/arcalot/arcaflow-plugin-wait.git@afdc2323805ffe2b37271f3a852a4ce7ac7379e1",
+		Location: "git+https://github.com/arcalot/arcaflow-plugin-utilities.git@0.6.1",
 	}
 
 	tempdir := "/tmp/pullmodule2"

--- a/internal/connector/connector_test.go
+++ b/internal/connector/connector_test.go
@@ -4,6 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"math/rand"
+	"os"
+	"os/exec"
+	"sync"
+	"testing"
+
 	"go.arcalot.io/assert"
 	"go.arcalot.io/exex"
 	"go.arcalot.io/log/v2"
@@ -13,12 +20,6 @@ import (
 	pythondeployer "go.flow.arcalot.io/pythondeployer"
 	"go.flow.arcalot.io/pythondeployer/internal/config"
 	"go.flow.arcalot.io/pythondeployer/internal/connector"
-	"io"
-	"math/rand"
-	"os"
-	"os/exec"
-	"sync"
-	"testing"
 )
 
 func GetPythonPath() (string, error) {
@@ -119,9 +120,9 @@ func TestDeployConcurrent_ConnectorsAndPluginsWithDifferentModules(t *testing.T)
 		// the 'latest' branch of cliwrapper.GetModulePath()
 		"wait": {
 			stepID:   "wait",
-			location: "arcaflow-plugin-wait@git+https://github.com/arcalot/arcaflow-plugin-wait.git",
+			location: "arcaflow-plugin-utilities@git+https://github.com/arcalot/arcaflow-plugin-utilities.git",
 			input: map[string]any{
-				"seconds": "0.5",
+				"wait_time_ms": "500",
 			},
 		},
 	}


### PR DESCRIPTION
## Changes introduced with this PR

Changing the plugin used in test conditions from the "wait" plugin to the "utilities" plugin. This is part of an effort to eliminate the "wait" plugin as redundant.


---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).